### PR TITLE
Fix (hopefully) GUI test crashes for #1018

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -92,7 +92,7 @@ jobs:
           pip-install-target: -r requirements-dev.txt ${{ matrix.optional-dependencies }}
       - name: Set common pytest flags
         run:
-          echo 'PYTEST_ADDOPTS=--verbose --artifacts-path "$PYTEST_ARTIFACTS_PATH"' >> $GITHUB_ENV
+          echo 'PYTEST_ADDOPTS=--pyargs foqus_lib --verbose --artifacts-path "$PYTEST_ARTIFACTS_PATH"' >> $GITHUB_ENV
       - name: Set up GUI test environment (Linux)
         if: contains(matrix.os, 'linux')
         run: |

--- a/foqus_lib/gui/tests/conftest.py
+++ b/foqus_lib/gui/tests/conftest.py
@@ -46,7 +46,7 @@ def qtbot(request, qapp, qtbot_params) -> pytest_qt_extras.QtBot:
         yield _qtbot
     if exceptions:
         pytest.fail(format_captured_exceptions(exceptions))
-    _qtbot.describe()
+    # _qtbot.cleanup()
 
 
 @pytest.fixture(scope="session")
@@ -81,15 +81,22 @@ def main_window(foqus_session, qtbot, main_window_params):
         showSDOE=False,
         ts=False,
     )
-    main_win.closeEvent = lambda *args, **kwargs: None
     print(f"main_win={main_win}")
     main_win.app = QtWidgets.QApplication.instance()
     print(f"main_win.app={main_win.app}")
-    # qtbot.addWidget(main_win)
+    # qtbot.add_widget(main_win)
     qtbot.waitForWindowShown(main_win)
     print(f"main_win.app.activeWindow()={main_win.app.activeWindow()}")
     yield main_win
-    main_win.close()
+
+    def handle_closing_prompt(w: QtWidgets.QMessageBox):
+        return QtWidgets.QMessageBox.No
+
+    with pytest_qt_extras._ModalPatcher(QtWidgets.QMessageBox).patching(
+        handle_closing_prompt
+    ):
+        main_win.close()
+    qtbot.cleanup()
 
 
 @pytest.fixture(scope="class")

--- a/foqus_lib/gui/tests/test_main_window.py
+++ b/foqus_lib/gui/tests/test_main_window.py
@@ -8,4 +8,4 @@ pytestmark = pytest.mark.gui
 
 def test_main_window_opens(qtbot, main_window):
     qtbot.slow_down()
-    main_window.close()
+    assert main_window is not None


### PR DESCRIPTION
## Motivation

- Fix non-OUU-specific crashes occurring during GUI tests that prevented #1018 from being merged

## Changes proposed in this PR:

- Add improved patching for handling modal dialogs that bypasses `exec_()` instead of requiring extra threads
- Improve cleanup for `main_window` and `qtbot` fixtures to avoid dangling references

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
